### PR TITLE
Use Keys object to import keys for better version compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ organization := "com.lightbend.sbt"
 
 // dependencies
 val packagerVersion = "1.0.6"
+val packager11xVersion = "1.1.5"
+val packager12xVersion = "1.2.0"
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % packagerVersion % "provided")
 
 // compile settings
@@ -33,7 +35,9 @@ lazy val maxwell = project
 scriptedSettings
 scriptedLaunchOpts ++= Seq(
   "-Dproject.version=" + version.value,
-  "-Dpackager.version=" + packagerVersion
+  "-Dpackager.version=" + packagerVersion,
+  "-Dpackager.11x.version=" + packager11xVersion,
+  "-Dpackager.12x.version=" + packager12xVersion
 )
 scriptedDependencies := {
   (publishLocal in maxwell).value

--- a/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
+++ b/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
@@ -21,11 +21,14 @@ object JavaAgentPackaging extends AutoPlugin {
 
   override def requires = JavaAgent && PluginRef("com.typesafe.sbt.packager.archetypes.JavaAppPackaging")
 
-  override def projectSettings = Seq(
-    mappings in Universal ++= agentMappings.value.map(m => m._1 -> m._2),
-    bashScriptExtraDefines ++= agentBashScriptOptions.value,
-    batScriptExtraDefines ++= agentBatScriptOptions.value
-  )
+  override def projectSettings = {
+    import com.typesafe.sbt.packager.Keys
+    Seq(
+      mappings in Universal ++= agentMappings.value.map(m => m._1 -> m._2),
+      Keys.bashScriptExtraDefines ++= agentBashScriptOptions.value,
+      Keys.batScriptExtraDefines ++= agentBatScriptOptions.value
+    )
+  }
 
   private def agentMappings = Def.task[Seq[(File, String, String)]] {
     resolvedJavaAgents.value filter (_.agent.scope.dist) map { resolved =>

--- a/src/sbt-test/agent/dist_1.1.x/build.sbt
+++ b/src/sbt-test/agent/dist_1.1.x/build.sbt
@@ -1,0 +1,3 @@
+lazy val agentDist = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+
+javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version")

--- a/src/sbt-test/agent/dist_1.1.x/project/plugins.sbt
+++ b/src/sbt-test/agent/dist_1.1.x/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent"       % sys.props("project.version"))
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager" % sys.props("packager.11x.version"))

--- a/src/sbt-test/agent/dist_1.1.x/src/main/scala/Main.scala
+++ b/src/sbt-test/agent/dist_1.1.x/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+object Main extends App

--- a/src/sbt-test/agent/dist_1.1.x/test
+++ b/src/sbt-test/agent/dist_1.1.x/test
@@ -1,0 +1,2 @@
+> stage
+> check

--- a/src/sbt-test/agent/dist_1.1.x/test.sbt
+++ b/src/sbt-test/agent/dist_1.1.x/test.sbt
@@ -1,0 +1,13 @@
+TaskKey[Unit]("check") := {
+  assert(
+    (mappings in Universal).value exists { case (file, path) => path == "maxwell/maxwell.jar" },
+    "dist mappings do not include 'maxwell/maxwell.jar'"
+  )
+
+  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+
+  assert(
+    output contains "Agent 86",
+    "output does not include 'Agent 86'"
+  )
+}

--- a/src/sbt-test/agent/dist_1.2.x/build.sbt
+++ b/src/sbt-test/agent/dist_1.2.x/build.sbt
@@ -1,0 +1,3 @@
+lazy val agentDist = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+
+javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version")

--- a/src/sbt-test/agent/dist_1.2.x/project/plugins.sbt
+++ b/src/sbt-test/agent/dist_1.2.x/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent"       % sys.props("project.version"))
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager" % sys.props("packager.12x.version"))

--- a/src/sbt-test/agent/dist_1.2.x/src/main/scala/Main.scala
+++ b/src/sbt-test/agent/dist_1.2.x/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+object Main extends App

--- a/src/sbt-test/agent/dist_1.2.x/test
+++ b/src/sbt-test/agent/dist_1.2.x/test
@@ -1,0 +1,2 @@
+> stage
+> check

--- a/src/sbt-test/agent/dist_1.2.x/test.sbt
+++ b/src/sbt-test/agent/dist_1.2.x/test.sbt
@@ -1,0 +1,13 @@
+TaskKey[Unit]("check") := {
+  assert(
+    (mappings in Universal).value exists { case (file, path) => path == "maxwell/maxwell.jar" },
+    "dist mappings do not include 'maxwell/maxwell.jar'"
+  )
+
+  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+
+  assert(
+    output contains "Agent 86",
+    "output does not include 'Agent 86'"
+  )
+}


### PR DESCRIPTION
Added tests for `dist` for `sbt-native-packager` 1.1.5 and 1.2.0 as well