### PR TITLE
Enable connectInput by default for the applications running from Sbt with this plugin enabled when fork is enabled.

### DIFF
--- a/src/main/scala/com/lightbend/sbt/javaagent/JavaAgent.scala
+++ b/src/main/scala/com/lightbend/sbt/javaagent/JavaAgent.scala
@@ -62,6 +62,7 @@ object JavaAgent extends AutoPlugin {
     libraryDependencies ++= javaAgents.value.map(_.module),
     resolvedJavaAgents := resolveAgents.value,
     fork in run := enableFork(fork in run, _.scope.run).value,
+    connectInput in run := enableFork(fork in run, _.scope.run).value,
     fork in Test := enableFork(fork in Test, _.scope.test).value,
     javaOptions in run ++= agentOptions(_.agent.scope.run).value,
     javaOptions in Test ++= agentOptions(_.agent.scope.test).value,


### PR DESCRIPTION
Otherwise it will not read user input from the standard input (console).

Closes #18