### PR TITLE
Extract JavaAgent class to make it open.

### DIFF
--- a/src/main/scala/com/lightbend/sbt/javaagent/JavaAgent.scala
+++ b/src/main/scala/com/lightbend/sbt/javaagent/JavaAgent.scala
@@ -12,16 +12,13 @@ import sbt.Keys._
  * Supports agents as compile-time dependencies, in forked tests, in forked run,
  * and in `sbt-native-packager` dists through the `JavaAgentPackaging` plugin.
  */
-object JavaAgent extends AutoPlugin {
+object JavaAgent extends JavaAgent {
+  val autoImport = JavaAgentKeys
 
   object JavaAgentKeys {
     val javaAgents = settingKey[Seq[AgentModule]]("Java agent modules enabled for this project.")
     val resolvedJavaAgents = taskKey[Seq[ResolvedAgent]]("Java agent modules with resolved artifacts.")
   }
-
-  import JavaAgentKeys._
-
-  val autoImport = JavaAgentKeys
 
   val AgentConfig = config("javaagent").hide
 
@@ -53,8 +50,13 @@ object JavaAgent extends AutoPlugin {
     val configuredScope = AgentScope(compile = inCompile, test = inTest, run = inRun, dist = inDist)
     AgentModule(agentName, reconfiguredModule, configuredScope, agentArguments)
   }
+}
 
-  override def requires = plugins.JvmPlugin
+class JavaAgent extends AutoPlugin {
+  import JavaAgent._
+  import JavaAgent.JavaAgentKeys._
+
+  override def requires: Plugins = plugins.JvmPlugin
 
   override def projectSettings = Seq(
     javaAgents := Seq.empty,


### PR DESCRIPTION
The main motivation for this change is to make it possible to extend the requires method to specify plugins ordering.

Making JavaAgent a class now it's possible to override the requires method, e.g.

```scala
object DatadogAgent extends JavaAgent {

  // Making sure that the Common plugin runs before JavaAgent because it resets javaOptions.
  // Otherwise the javaagent setting will be vanished.
  override def requires = super.requires && Common

  override def projectSettings = super.projectSettings ++ Seq(
    javaAgents += Library.datadogJavaAgent % "test"
  )
}
```