### PR TITLE
Replace Travis with Github Actions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,21 @@
+name: Scala CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Run tests
+      run: sbt "^ scripted"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: scala
-jdk: oraclejdk8
-script: sbt "^ scripted"


### PR DESCRIPTION
Turns out that Travis doesn't support Java 8 anymore.

See https://travis-ci.org/github/sbt/sbt-javaagent/jobs/738370710