### PR TITLE
fix: require bash script plugin when packaging

### DIFF
--- a/src/main/scala-sbt-0.13/com/lightbend/sbt/javaagent/Dependencies.scala
+++ b/src/main/scala-sbt-0.13/com/lightbend/sbt/javaagent/Dependencies.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright © 2016-2023 Lightbend, Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.sbt.javaagent
+
+object Dependencies {
+  // no bash script plugin dependency for sbt 0.13
+  val BashStartScriptPlugin = "sbt.plugins.JvmPlugin"
+}

--- a/src/main/scala-sbt-1.0/com/lightbend/sbt/javaagent/Dependencies.scala
+++ b/src/main/scala-sbt-1.0/com/lightbend/sbt/javaagent/Dependencies.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright © 2016-2023 Lightbend, Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.sbt.javaagent
+
+object Dependencies {
+  val BashStartScriptPlugin = "com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptPlugin"
+}

--- a/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
+++ b/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
@@ -19,7 +19,7 @@ object JavaAgentPackaging extends AutoPlugin {
 
   override def requires = JavaAgent &&
     PluginRef("com.typesafe.sbt.packager.archetypes.JavaAppPackaging") &&
-    PluginRef("com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptPlugin")
+    PluginRef(Dependencies.BashStartScriptPlugin)
 
   override def projectSettings = {
     import com.typesafe.sbt.packager.{ Keys => PackagerKeys }

--- a/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
+++ b/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
@@ -17,7 +17,9 @@ object JavaAgentPackaging extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = JavaAgent && PluginRef("com.typesafe.sbt.packager.archetypes.JavaAppPackaging")
+  override def requires = JavaAgent &&
+    PluginRef("com.typesafe.sbt.packager.archetypes.JavaAppPackaging") &&
+    PluginRef("com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptPlugin")
 
   override def projectSettings = {
     import com.typesafe.sbt.packager.{ Keys => PackagerKeys }


### PR DESCRIPTION
Fixes #28. Make sure bash script plugin default settings are applied first.