### PR TITLE
Migrate to sbt 1.x syntax

### DIFF
--- a/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
+++ b/src/main/scala/com/lightbend/sbt/javaagent/JavaAgentPackaging.scala
@@ -24,7 +24,7 @@ object JavaAgentPackaging extends AutoPlugin {
   override def projectSettings = {
     import com.typesafe.sbt.packager.{ Keys => PackagerKeys }
     Seq(
-      mappings in Universal ++= agentMappings.value.map(m => m._1 -> m._2),
+      Universal / mappings ++= agentMappings.value.map(m => m._1 -> m._2),
       PackagerKeys.bashScriptExtraDefines ++= agentBashScriptOptions.value,
       PackagerKeys.batScriptExtraDefines ++= agentBatScriptOptions.value
     )

--- a/src/sbt-test/agent/arguments/build.sbt
+++ b/src/sbt-test/agent/arguments/build.sbt
@@ -1,4 +1,9 @@
-lazy val agentOptions = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+lazy val agentOptions =
+  project.in(file(".")).enablePlugins(JavaAgent, JavaAppPackaging)
 
-javaAgents += JavaAgent(module = "sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "dist;test",
-  arguments = "Get_Smart;Agent_99")
+javaAgents += JavaAgent(
+  module = "sbt.javaagent.test" % "maxwell" % sys.props(
+    "project.version"
+  ) % "dist;test",
+  arguments = "Get_Smart;Agent_99"
+)

--- a/src/sbt-test/agent/arguments/test.sbt
+++ b/src/sbt-test/agent/arguments/test.sbt
@@ -1,26 +1,35 @@
 TaskKey[Unit]("check") := {
   assert(
-    (fork in Test).value,
-    "fork in Test is not enabled"
+    (Test / fork).value,
+    "Test / fork is not enabled"
   )
 
   assert(
-    (javaOptions in Test).value exists (s => s.contains("-javaagent:") && s.contains("maxwell")),
-    "javaOptions in Test do not contain 'maxwell' agent"
+    (Test / javaOptions).value exists (s =>
+      s.contains("-javaagent:") && s.contains("maxwell")
+    ),
+    "Test / javaOptions do not contain 'maxwell' agent"
   )
 
   assert(
-    (javaOptions in Test).value exists (s => s.contains("-javaagent:") && s.contains("maxwell") && s.contains("=Get_Smart;Agent_99")),
-    "javaOptions in Test do not contain 'Get_Smart;Agent_99' agent arguments"
+    (Test / javaOptions).value exists (s =>
+      s.contains("-javaagent:") && s.contains("maxwell") && s.contains(
+        "=Get_Smart;Agent_99"
+      )
+    ),
+    "Test / javaOptions do not contain 'Get_Smart;Agent_99' agent arguments"
   )
 
   assert(
-    (mappings in Universal).value exists { case (file, path) => path == "maxwell/maxwell.jar" },
+    (Universal / mappings).value exists { case (file, path) =>
+      path == "maxwell/maxwell.jar"
+    },
     "dist mappings do not include 'maxwell/maxwell.jar'"
   )
 
   import scala.sys.process._
-  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+  val output =
+    ((Universal / stagingDirectory).value / "bin" / packageName.value).absolutePath.!!
 
   assert(
     !(output contains "Agent 86"),

--- a/src/sbt-test/agent/compile/build.sbt
+++ b/src/sbt-test/agent/compile/build.sbt
@@ -1,3 +1,6 @@
-lazy val agentCompile = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+lazy val agentCompile =
+  project.in(file(".")).enablePlugins(JavaAgent, JavaAppPackaging)
 
-javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "compile"
+javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props(
+  "project.version"
+) % "compile"

--- a/src/sbt-test/agent/compile/test.sbt
+++ b/src/sbt-test/agent/compile/test.sbt
@@ -1,6 +1,7 @@
 TaskKey[Unit]("checkDependency") := {
   assert(
-    libraryDependencies.value contains ("sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "provided"),
+    libraryDependencies.value contains ("sbt.javaagent.test" % "maxwell" % sys
+      .props("project.version") % "provided"),
     "maxwell test agent is not in libraryDependencies under 'provided'"
   )
 }
@@ -16,22 +17,29 @@ TaskKey[Unit]("checkLog") := {
 
 TaskKey[Unit]("checkDist") := {
   import scala.sys.process._
-  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+  val output =
+    ((Universal / stagingDirectory).value / "bin" / packageName.value).absolutePath.!!
   expect("dist run", output, "Agent 86")
   expect("dist run", output, "class maxwell.Maxwell")
 }
 
 TaskKey[Unit]("checkTestAndRunPaths") := {
   assert(
-    !((dependencyClasspath in Runtime).value exists (f => f.data.name.contains("maxwell"))),
+    !((Runtime / dependencyClasspath).value exists (f =>
+      f.data.name.contains("maxwell")
+    )),
     "maxwell test agent is available on the runtime class path"
   )
   assert(
-    (dependencyClasspath in Test).value exists (f => f.data.name.contains("maxwell")),
+    (Test / dependencyClasspath).value exists (f =>
+      f.data.name.contains("maxwell")
+    ),
     "maxwell test agent is not available on the test compile class path"
   )
   assert(
-    !((fullClasspath in Test).value exists (f => f.data.name.contains("maxwell"))),
+    !((Test / fullClasspath).value exists (f =>
+      f.data.name.contains("maxwell")
+    )),
     "maxwell test agent is available on the test run class path"
   )
 }

--- a/src/sbt-test/agent/confs/build.sbt
+++ b/src/sbt-test/agent/confs/build.sbt
@@ -1,4 +1,4 @@
-lazy val agentConfs = project in file(".") enablePlugins JavaAgent
+lazy val agentConfs = project.in(file(".")).enablePlugins(JavaAgent)
 
 javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "compile;test"
 

--- a/src/sbt-test/agent/dist/build.sbt
+++ b/src/sbt-test/agent/dist/build.sbt
@@ -1,3 +1,4 @@
-lazy val agentDist = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+lazy val agentDist =
+  project.in(file(".")).enablePlugins(JavaAgent, JavaAppPackaging)
 
 javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version")

--- a/src/sbt-test/agent/dist/test.sbt
+++ b/src/sbt-test/agent/dist/test.sbt
@@ -1,11 +1,14 @@
 TaskKey[Unit]("check") := {
   assert(
-    (mappings in Universal).value exists { case (file, path) => path == "maxwell/maxwell.jar" },
+    (Universal / mappings).value exists { case (file, path) =>
+      path == "maxwell/maxwell.jar"
+    },
     "dist mappings do not include 'maxwell/maxwell.jar'"
   )
 
   import scala.sys.process._
-  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+  val output =
+    ((Universal / stagingDirectory).value / "bin" / packageName.value).absolutePath.!!
 
   assert(
     output contains "Agent 86",

--- a/src/sbt-test/agent/dist_1.9.x/build.sbt
+++ b/src/sbt-test/agent/dist_1.9.x/build.sbt
@@ -1,3 +1,4 @@
-lazy val agentDist = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+lazy val agentDist =
+  project.in(file(".")).enablePlugins(JavaAgent, JavaAppPackaging)
 
 javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version")

--- a/src/sbt-test/agent/dist_1.9.x/test.sbt
+++ b/src/sbt-test/agent/dist_1.9.x/test.sbt
@@ -1,11 +1,14 @@
 TaskKey[Unit]("check") := {
   assert(
-    (mappings in Universal).value exists { case (file, path) => path == "maxwell/maxwell.jar" },
+    (Universal / mappings).value exists { case (file, path) =>
+      path == "maxwell/maxwell.jar"
+    },
     "dist mappings do not include 'maxwell/maxwell.jar'"
   )
 
   import scala.sys.process._
-  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+  val output =
+    ((Universal / stagingDirectory).value / "bin" / packageName.value).absolutePath.!!
 
   assert(
     output contains "Agent 86",

--- a/src/sbt-test/agent/named/build.sbt
+++ b/src/sbt-test/agent/named/build.sbt
@@ -1,3 +1,7 @@
-lazy val agentNamed = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+lazy val agentNamed =
+  project.in(file(".")).enablePlugins(JavaAgent, JavaAppPackaging)
 
-javaAgents += JavaAgent(name = "Get Smart", module = "sbt.javaagent.test" % "maxwell" % sys.props("project.version"))
+javaAgents += JavaAgent(
+  name = "Get Smart",
+  module = "sbt.javaagent.test" % "maxwell" % sys.props("project.version")
+)

--- a/src/sbt-test/agent/named/test.sbt
+++ b/src/sbt-test/agent/named/test.sbt
@@ -1,11 +1,14 @@
 TaskKey[Unit]("check") := {
   assert(
-    (mappings in Universal).value exists { case (file, path) => path == "get-smart/maxwell.jar" },
+    (Universal / mappings).value exists { case (file, path) =>
+      path == "get-smart/maxwell.jar"
+    },
     "dist mappings do not include 'get-smart/maxwell.jar'"
   )
 
   import scala.sys.process._
-  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+  val output =
+    ((Universal / stagingDirectory).value / "bin" / packageName.value).absolutePath.!!
 
   assert(
     output contains "Agent 86",

--- a/src/sbt-test/agent/provided/build.sbt
+++ b/src/sbt-test/agent/provided/build.sbt
@@ -1,3 +1,6 @@
-lazy val agentProvided = project in file(".") enablePlugins (JavaAgent, JavaAppPackaging)
+lazy val agentProvided =
+  project.in(file(".")).enablePlugins(JavaAgent, JavaAppPackaging)
 
-javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "provided"
+javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props(
+  "project.version"
+) % "provided"

--- a/src/sbt-test/agent/provided/test.sbt
+++ b/src/sbt-test/agent/provided/test.sbt
@@ -8,7 +8,8 @@ TaskKey[Unit]("check") := {
   expect("run log", log, "class maxwell.Maxwell")
 
   import scala.sys.process._
-  val output = ((stagingDirectory in Universal).value / "bin" / packageName.value).absolutePath.!!
+  val output =
+    ((Universal / stagingDirectory).value / "bin" / packageName.value).absolutePath.!!
 
   expect("dist run", output, "Agent 86")
   expect("dist run", output, "class maxwell.Maxwell")

--- a/src/sbt-test/agent/run/build.sbt
+++ b/src/sbt-test/agent/run/build.sbt
@@ -1,3 +1,5 @@
-lazy val agentRun = project in file(".") enablePlugins JavaAgent
+lazy val agentRun = project.in(file(".")).enablePlugins(JavaAgent)
 
-javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "runtime"
+javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props(
+  "project.version"
+) % "runtime"

--- a/src/sbt-test/agent/run/test.sbt
+++ b/src/sbt-test/agent/run/test.sbt
@@ -1,17 +1,20 @@
 TaskKey[Unit]("check") := {
   assert(
-    libraryDependencies.value contains ("sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "javaagent"),
+    libraryDependencies.value contains ("sbt.javaagent.test" % "maxwell" % sys
+      .props("project.version") % "javaagent"),
     "maxwell test agent is not in libraryDependencies under 'javaagent'"
   )
 
   assert(
-    (fork in run).value,
-    "fork in run is not enabled"
+    (run / fork).value,
+    "run / fork is not enabled"
   )
 
   assert(
-    (javaOptions in run).value exists (s => s.contains("-javaagent:") && s.contains("maxwell")),
-    "javaOptions in run do not contain 'maxwell' agent"
+    (run / javaOptions).value exists (s =>
+      s.contains("-javaagent:") && s.contains("maxwell")
+    ),
+    "run / javaOptions do not contain 'maxwell' agent"
   )
 
   val runLog = IO.read(file("run.log"))

--- a/src/sbt-test/agent/test/build.sbt
+++ b/src/sbt-test/agent/test/build.sbt
@@ -1,20 +1,37 @@
-lazy val agentTest = project in file(".") enablePlugins JavaAgent
+lazy val agentTest = project.in(file(".")).enablePlugins(JavaAgent)
 
-javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props("project.version") % "test"
+javaAgents += "sbt.javaagent.test" % "maxwell" % sys.props(
+  "project.version"
+) % "test"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 
 // send test stdout to log — works but should be easier?
 // outputStrategy is a setting, so it can't access tasks like streams
-testGrouping in Test := {
-  (testGrouping in Test).value map {
+Test / testGrouping := {
+  (Test / testGrouping).value map {
     case group @ Tests.Group(_, _, Tests.SubProcess(forkOptions)) =>
-      group.copy(runPolicy = Tests.SubProcess(copyForkOptions(forkOptions, LoggedOutput(streams.value.log))))
+      group.copy(runPolicy =
+        Tests.SubProcess(
+          copyForkOptions(forkOptions, LoggedOutput(streams.value.log))
+        )
+      )
     case group => group
   }
 }
 
 // copy manually to be compatible with both sbt 0.13 (case class) and sbt 1.0 (contraband)
-def copyForkOptions(o: ForkOptions, newOutputStrategy: OutputStrategy): ForkOptions = {
-  ForkOptions(o.javaHome, Some(newOutputStrategy), o.bootJars, o.workingDirectory, o.runJVMOptions, o.connectInput, o.envVars)
+def copyForkOptions(
+    o: ForkOptions,
+    newOutputStrategy: OutputStrategy
+): ForkOptions = {
+  ForkOptions(
+    o.javaHome,
+    Some(newOutputStrategy),
+    o.bootJars,
+    o.workingDirectory,
+    o.runJVMOptions,
+    o.connectInput,
+    o.envVars
+  )
 }

--- a/src/sbt-test/agent/test/test.sbt
+++ b/src/sbt-test/agent/test/test.sbt
@@ -1,16 +1,20 @@
 TaskKey[Unit]("check") := {
   assert(
-    (fork in Test).value,
-    "fork in Test is not enabled"
+    (Test / fork).value,
+    "Test / fork is not enabled"
   )
 
   assert(
-    (javaOptions in Test).value exists (s => s.contains("-javaagent:") && s.contains("maxwell")),
-    "javaOptions in Test do not contain 'maxwell' agent"
+    (Test / javaOptions).value exists (s =>
+      s.contains("-javaagent:") && s.contains("maxwell")
+    ),
+    "Test / javaOptions do not contain 'maxwell' agent"
   )
 
   assert(
-    !((fullClasspath in Test).value exists (f => f.data.name.contains("maxwell"))),
+    !((Test / fullClasspath).value exists (f =>
+      f.data.name.contains("maxwell")
+    )),
     "maxwell test agent is available on the test run class path"
   )
 


### PR DESCRIPTION
Followup to https://github.com/sbt/sbt-javaagent/pull/32 replacing sbt 0.13.x syntax 